### PR TITLE
Use static properties for configuration helper values that do not change

### DIFF
--- a/src/Spryker/Shared/Kernel/Transfer/AbstractEntityTransfer.php
+++ b/src/Spryker/Shared/Kernel/Transfer/AbstractEntityTransfer.php
@@ -15,14 +15,14 @@ class AbstractEntityTransfer extends AbstractTransfer implements EntityTransferI
      *
      * @var array
      */
-    protected $virtualProperties = [];
+    protected static $virtualProperties = [];
 
     /**
      * @return array
      */
     public function virtualProperties()
     {
-        return $this->virtualProperties;
+        return static::$virtualProperties;
     }
 
     /**
@@ -35,16 +35,16 @@ class AbstractEntityTransfer extends AbstractTransfer implements EntityTransferI
     {
         foreach ($data as $property => $value) {
             if ($this->hasProperty($property, $acceptVirtualProperties) === false) {
-                $this->virtualProperties[$property] = $value;
+                static::$virtualProperties[$property] = $value;
                 continue;
             }
 
-            $property = $this->transferPropertyNameMap[$property];
+            $property = static::$transferPropertyNameMap[$property];
 
-            if ($this->transferMetadata[$property]['is_collection']) {
-                $elementType = $this->transferMetadata[$property]['type'];
+            if (static::$transferMetadata[$property]['is_collection']) {
+                $elementType = static::$transferMetadata[$property]['type'];
                 $value = $this->processArrayObject($elementType, $value, $acceptVirtualProperties);
-            } elseif ($this->transferMetadata[$property]['is_transfer']) {
+            } elseif (static::$transferMetadata[$property]['is_transfer']) {
                 $value = $this->initializeNestedTransferObject($property, $value, $acceptVirtualProperties);
             }
 

--- a/src/Spryker/Shared/Kernel/Transfer/AbstractTransfer.php
+++ b/src/Spryker/Shared/Kernel/Transfer/AbstractTransfer.php
@@ -27,12 +27,12 @@ abstract class AbstractTransfer implements TransferInterface, Serializable, Arra
     /**
      * @var array
      */
-    protected $transferMetadata = [];
+    protected static $transferMetadata = [];
 
     /**
      * @var array
      */
-    protected $transferPropertyNameMap = [];
+    protected static $transferPropertyNameMap = [];
 
     public function __construct()
     {
@@ -101,13 +101,13 @@ abstract class AbstractTransfer implements TransferInterface, Serializable, Arra
             if ($camelCasedKeys) {
                 $arrayKey = $property;
             } else {
-                $arrayKey = $this->transferMetadata[$property]['name_underscore'];
+                $arrayKey = static::$transferMetadata[$property]['name_underscore'];
             }
 
             if (is_object($value)) {
                 if ($isRecursive && $value instanceof TransferInterface) {
                     $values[$arrayKey] = $value->$childConvertMethodName($isRecursive, $camelCasedKeys);
-                } elseif ($isRecursive && $this->transferMetadata[$property]['is_collection'] && count($value) >= 1) {
+                } elseif ($isRecursive && static::$transferMetadata[$property]['is_collection'] && count($value) >= 1) {
                     $values = $this->addValuesToCollection($value, $values, $arrayKey, $isRecursive, $childConvertMethodName, $camelCasedKeys);
                 } else {
                     $values[$arrayKey] = $value;
@@ -126,7 +126,7 @@ abstract class AbstractTransfer implements TransferInterface, Serializable, Arra
      */
     private function getPropertyNames()
     {
-        return array_keys($this->transferMetadata);
+        return array_keys(static::$transferMetadata);
     }
 
     /**
@@ -142,12 +142,12 @@ abstract class AbstractTransfer implements TransferInterface, Serializable, Arra
                 continue;
             }
 
-            $property = $this->transferPropertyNameMap[$property];
+            $property = static::$transferPropertyNameMap[$property];
 
-            if ($this->transferMetadata[$property]['is_collection']) {
-                $elementType = $this->transferMetadata[$property]['type'];
+            if (static::$transferMetadata[$property]['is_collection']) {
+                $elementType = static::$transferMetadata[$property]['type'];
                 $value = $this->processArrayObject($elementType, $value, $ignoreMissingProperty);
-            } elseif ($this->transferMetadata[$property]['is_transfer']) {
+            } elseif (static::$transferMetadata[$property]['is_transfer']) {
                 $value = $this->initializeNestedTransferObject($property, $value, $ignoreMissingProperty);
             }
 
@@ -241,7 +241,7 @@ abstract class AbstractTransfer implements TransferInterface, Serializable, Arra
      */
     protected function initializeNestedTransferObject($property, $value, $ignoreMissingProperty = false)
     {
-        $type = $this->transferMetadata[$property]['type'];
+        $type = static::$transferMetadata[$property]['type'];
 
         /** @var \Spryker\Shared\Kernel\Transfer\TransferInterface $transferObject */
         $transferObject = new $type();
@@ -264,7 +264,7 @@ abstract class AbstractTransfer implements TransferInterface, Serializable, Arra
      */
     protected function hasProperty($property, $ignoreMissingProperty)
     {
-        if (isset($this->transferPropertyNameMap[$property])) {
+        if (isset(static::$transferPropertyNameMap[$property])) {
             return true;
         }
 
@@ -352,7 +352,7 @@ abstract class AbstractTransfer implements TransferInterface, Serializable, Arra
      */
     public function offsetExists($offset)
     {
-        return isset($this->transferMetadata[$offset]);
+        return isset(static::$transferMetadata[$offset]);
     }
 
     /**


### PR DESCRIPTION
This is a small improvement to use static properties for the property maps of a transfer. There is no reason to have this as an instance variable as every transfer injects its own properties and will always keep them the same.

This _might_ improve performance, I'm not sure how much though.

But: It makes dumping a transfer easier as the property maps, which are just noise when dumping, will not be dumped because they are static (i.e. when using the var dumper).

If this is merged, be sure to also merge the PR in the transfer repo as well, as the template generators for the concrete transfers need to be adapted as well.