### PR TITLE
Fix wrong getLocator docblock

### DIFF
--- a/src/Spryker/Client/Kernel/Container.php
+++ b/src/Spryker/Client/Kernel/Container.php
@@ -12,7 +12,7 @@ use Spryker\Shared\Kernel\Container\AbstractApplicationContainer;
 class Container extends AbstractApplicationContainer
 {
     /**
-     * @return \Generated\Client\Ide\AutoCompletion|\Spryker\Shared\Kernel\LocatorLocatorInterface
+     * @return \Generated\Client\Ide\AutoCompletion&\Spryker\Shared\Kernel\LocatorLocatorInterface
      */
     public function getLocator()
     {

--- a/src/Spryker/Glue/Kernel/Container.php
+++ b/src/Spryker/Glue/Kernel/Container.php
@@ -12,7 +12,7 @@ use Spryker\Shared\Kernel\Container\AbstractApplicationContainer;
 class Container extends AbstractApplicationContainer
 {
     /**
-     * @return \Generated\Glue\Ide\AutoCompletion|\Spryker\Shared\Kernel\LocatorLocatorInterface
+     * @return \Generated\Glue\Ide\AutoCompletion&\Spryker\Shared\Kernel\LocatorLocatorInterface
      */
     public function getLocator()
     {

--- a/src/Spryker/Service/Kernel/Container.php
+++ b/src/Spryker/Service/Kernel/Container.php
@@ -12,7 +12,7 @@ use Spryker\Shared\Kernel\Container\AbstractApplicationContainer;
 class Container extends AbstractApplicationContainer
 {
     /**
-     * @return \Generated\Service\Ide\AutoCompletion|\Spryker\Shared\Kernel\LocatorLocatorInterface
+     * @return \Generated\Service\Ide\AutoCompletion&\Spryker\Shared\Kernel\LocatorLocatorInterface
      */
     public function getLocator()
     {

--- a/src/Spryker/Yves/Kernel/Container.php
+++ b/src/Spryker/Yves/Kernel/Container.php
@@ -12,7 +12,7 @@ use Spryker\Shared\Kernel\Container\AbstractApplicationContainer;
 class Container extends AbstractApplicationContainer
 {
     /**
-     * @return \Generated\Yves\Ide\AutoCompletion|\Spryker\Shared\Kernel\LocatorLocatorInterface
+     * @return \Generated\Yves\Ide\AutoCompletion&\Spryker\Shared\Kernel\LocatorLocatorInterface
      */
     public function getLocator()
     {

--- a/src/Spryker/Zed/Kernel/Container.php
+++ b/src/Spryker/Zed/Kernel/Container.php
@@ -12,7 +12,7 @@ use Spryker\Shared\Kernel\Container\AbstractApplicationContainer;
 class Container extends AbstractApplicationContainer
 {
     /**
-     * @return \Generated\Zed\Ide\AutoCompletion|\Spryker\Shared\Kernel\LocatorLocatorInterface
+     * @return \Generated\Zed\Ide\AutoCompletion&\Spryker\Shared\Kernel\LocatorLocatorInterface
      */
     public function getLocator()
     {


### PR DESCRIPTION
## PR Description

We have a ton of PHPStan errors when using the locator, that look like this:
```
 ------ ------------------------------------------------------------------------------------------------
  Line   SynchronizationFacadeTest.php
 ------ ------------------------------------------------------------------------------------------------
  26     Call to an undefined method
         Generated\Client\Ide\AutoCompletion|Spryker\Shared\Kernel\LocatorLocatorInterface::rabbitMq().
 ------ ------------------------------------------------------------------------------------------------
```

The code that causes this:
```php
$this->tester->setDependency(QueueDependencyProvider::QUEUE_ADAPTERS, function (Container $container) {
    return [
        $container->getLocator()->rabbitMq()->client()->createQueueAdapter(),
    ];
});
```

## Checklist
- [x] I agree with the Code Contribution License Agreement in CONTRIBUTING.md

----

We're currently using a stubFile for this:
```php
<?php # content of phpstan-stubs/Container.stub 

namespace Spryker\Shared\Kernel\Container {
    class AbstractApplicationContainer {}
}
namespace Generated\Client\Ide {
    interface AutoCompletion {}
}
namespace Spryker\Shared\Kernel {
    interface LocatorLocatorInterface {}
}

namespace Spryker\Client\Kernel {
    use Spryker\Shared\Kernel\Container\AbstractApplicationContainer;

    class Container extends AbstractApplicationContainer
    {
        /**
         * @return \Generated\Client\Ide\AutoCompletion&\Spryker\Shared\Kernel\LocatorLocatorInterface
         */
        public function getLocator()
        {}
    }
}
```
```neon
parameters:
    stubFiles:
        - phpstan-stubs/Container.stub
```